### PR TITLE
[Firefox] Fix exclusionList not defined error

### DIFF
--- a/French Academic Proxy - Firefox/background.js
+++ b/French Academic Proxy - Firefox/background.js
@@ -1,5 +1,9 @@
 // background.js
 
+const exclusionList = [
+  "static-content.springer.com"
+];
+
 // Store the original URL only once before any modification
 function storeOriginalUrl(url) {
   const urlObj = new URL(url);
@@ -107,10 +111,6 @@ browser.webNavigation.onCompleted.addListener((details) => {
   storeOriginalUrl(details.url);
 }, { url: [{hostContains: "www"}] });
 
-const exclusionList = [
-  "static-content.springer.com"  
-];
-    
 function getDomainsToModify(modificationType) {
   // Define and return the appropriate set of domains based on the modification type
   if (modificationType === "INSERM") {
@@ -233,8 +233,8 @@ function getDomainsToModify(modificationType) {
 "taylorfrancis.com",
 "thieme-connect.com",
 "webofknowledge.com"];
-  } 
-    
+  }
+
 else if (modificationType === "CNRS") {
     return ["access.clarivate.com",
 "apps.webofknowledge.com",


### PR DESCRIPTION
Fix error in Firefox introduced by the November update that breaks functionality of the extension:
in the function `modifyURL` and error `extensionList undefined` was raised due to a change of the function definition position. This should work fine now.